### PR TITLE
remove name function for now

### DIFF
--- a/wit/psh.wit
+++ b/wit/psh.wit
@@ -1,7 +1,6 @@
 package psh:profiling;
 
 world bindings {
-    import name: func() -> string;
     include profiling:system/imports@0.0.0;
     include profiling:perf/imports@0.0.0;
 }


### PR DESCRIPTION
Since we don't have real use for name function right now, and we don't know how to link this function in new version of wasmtime(and don't want to spend too much time to figure it out.), we remove this function in this PR, should we need something like this in the future, we'll figure out how to do this properly.